### PR TITLE
Include title tooltip 'showColumns' menu

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1105,8 +1105,8 @@
 
                 if (column.switchable) {
                     html.push(sprintf('<li>' +
-                        '<label><input type="checkbox" data-field="%s" value="%s"%s> %s</label>' +
-                        '</li>', column.field, i, checked, column.title));
+                        '<label title="%s"><input type="checkbox" data-field="%s" value="%s"%s> %s</label>' +
+                        '</li>', column.titleTooltip ||'', column.field, i, checked, column.title));
                     switchableCount++;
                 }
             });


### PR DESCRIPTION
The `titleTooltip`used in the column definition should be reused when choosing columns in the menu. 

I'm using an ellipsis for long title's and I'm using the title tooltip to show the complete title. With these change the complete title will also be available in the menu.
